### PR TITLE
Update .env

### DIFF
--- a/ai-assistant-bot/.env
+++ b/ai-assistant-bot/.env
@@ -1,2 +1,2 @@
-BEDROCK_ENDPOINT=bedrock.us-east-1.amazonaws.com
+BEDROCK_ENDPOINT=bedrock-runtime.us-east-1.amazonaws.com
 AWS_REGION=us-east-1


### PR DESCRIPTION
The bedrock enpoint env variable is missing the `-runtime` after bedrock so it works as expected.

*Issue #, if available:*

*Description of changes:*
Change the .env bedrock url

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
